### PR TITLE
Fix gemfile vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'httpclient', '~> 2.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     addressable (2.3.7)
     builder (3.2.2)
@@ -34,19 +34,19 @@ GEM
       rdoc
     json (1.8.2)
     jwt (1.2.1)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (~> 1.2)
-    rack (1.6.0)
+    rack (1.6.4)
     rake (10.4.2)
     rdoc (4.2.0)
       json (~> 1.4)
@@ -87,4 +87,4 @@ DEPENDENCIES
   webmock (~> 1.18)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Checking the gemfile with [`bundler-audit`](https://github.com/rubysec/bundler-audit) revealed a few issues:

- Nokogiri issue [#1374](https://github.com/sparklemotion/nokogiri/issues/1374) for `1.6.6.2`
- Nokogiri issue with libxml2 for `1.6.6.2` ([first](https://groups.google.com/forum/#!topic/ruby-security-ann/aSbgDiwb24s), [second](https://groups.google.com/forum/#!topic/ruby-security-ann/Dy7YiKb_pMM))
- Rack [security vulnerability issue](https://groups.google.com/forum/#!topic/ruby-security-ann/gcUbICUmKMc) for `1.6.0`
- Insecure source URI (`http` not `https` for `rubygems.org`)

This updates the relevant gems and resolves these issues.

@kaip 
