### PR TITLE
Allow for a user provided HTTPClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ Endpoint: basic_pages
 ...
 ```
 
+## Debugging
+
+The `NationBuilder::Client` object exposes the HTTPClient instance used to make the calls, so you can do any debugging or mocking against that:
+
+```Ruby
+client = NationBuilder::Client.new(nation_builder_slug, nation_builder_auth_token, retries: 8)
+client.http_client.debug_dev = STDOUT
+```
 ## Development
 
 To update the API specification that powers this client, first make

--- a/README.md
+++ b/README.md
@@ -123,14 +123,15 @@ Endpoint: basic_pages
 ...
 ```
 
-## Debugging
+## Modifying the underlying HTTPClient
 
-The `NationBuilder::Client` object exposes the HTTPClient instance used to make the calls, so you can do any debugging or mocking against that:
+The `NationBuilder::Client` object can use a provided [HTTPClient](http://www.rubydoc.info/gems/httpclient/frames) object if you need some customizations, such as to enable logging, change TLS settings, or add a proxy. For example to force a proxy for all traffic:
 
 ```Ruby
-client = NationBuilder::Client.new(nation_builder_slug, nation_builder_auth_token, retries: 8)
-client.http_client.debug_dev = STDOUT
+httpclient = HTTPClient.new('http://myproxy:8080')
+client = NationBuilder::Client.new(nation_builder_slug, nation_builder_auth_token, retries: 8, http_client: httpclient)
 ```
+
 ## Development
 
 To update the API specification that powers this client, first make

--- a/lib/nationbuilder/client.rb
+++ b/lib/nationbuilder/client.rb
@@ -6,6 +6,7 @@ class NationBuilder::Client
     @name_to_endpoint = {}
     @base_url = opts[:base_url] || 'https://:nation_name.nationbuilder.com'
     @retries = opts[:retries] || 8
+    @http_client = opts[:http_client] || HTTPClient.new
 
     if @retries < 0
       raise 'Retries must be at least zero'
@@ -14,10 +15,6 @@ class NationBuilder::Client
     parsed_endpoints.each do |endpoint|
       @name_to_endpoint[endpoint.name] = endpoint
     end
-  end
-
-  def http_client
-    @http_client ||= HTTPClient.new
   end
 
   def parsed_endpoints
@@ -85,7 +82,7 @@ class NationBuilder::Client
 
     (@retries + 1).times do |i|
       begin
-        raw_response = http_client.send(method, url, request_args)
+        raw_response = @http_client.send(method, url, request_args)
         parsed_response = parse_response_body(raw_response)
       rescue NationBuilder::RateLimitedError => e
         exception_to_reraise = e

--- a/lib/nationbuilder/client.rb
+++ b/lib/nationbuilder/client.rb
@@ -16,6 +16,10 @@ class NationBuilder::Client
     end
   end
 
+  def http_client
+    @http_client ||= HTTPClient.new
+  end
+
   def parsed_endpoints
     NationBuilder::SpecParser
       .parse(File.join(File.dirname(__FILE__), '..', 'api_spec/spec.json'))
@@ -81,7 +85,7 @@ class NationBuilder::Client
 
     (@retries + 1).times do |i|
       begin
-        raw_response = HTTPClient.send(method, url, request_args)
+        raw_response = http_client.send(method, url, request_args)
         parsed_response = parse_response_body(raw_response)
       rescue NationBuilder::RateLimitedError => e
         exception_to_reraise = e

--- a/spec/lib/nationbuilder/client_spec.rb
+++ b/spec/lib/nationbuilder/client_spec.rb
@@ -2,17 +2,23 @@ require 'spec_helper'
 
 describe NationBuilder::Client do
 
-  let(:client) do
+  subject do
     NationBuilder::Client.new('organizeralexandreschmitt',
                               '03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3',
                               retries: 1
                               )
   end
 
+  let(:http_client) { HTTPClient.new }
+
+  before do
+    allow(subject).to receive(:http_client).and_return(http_client)
+  end
+
   describe '#endpoints' do
 
     it 'should contain all defined endpoints' do
-      expect(client.endpoints.sort).to eq([
+      expect(subject.endpoints.sort).to eq([
         :basic_pages,
         :blog_posts,
         :blogs,
@@ -42,7 +48,7 @@ describe NationBuilder::Client do
   describe '#base_url' do
 
     it 'should contain the nation slug' do
-      expect(client.base_url).to eq('https://organizeralexandreschmitt.nationbuilder.com')
+      expect(subject.base_url).to eq('https://organizeralexandreschmitt.nationbuilder.com')
     end
   end
 
@@ -50,7 +56,7 @@ describe NationBuilder::Client do
 
     it 'should handle a parametered GET' do
       VCR.use_cassette('parametered_get') do
-        response = client.call(:basic_pages, :index, site_slug: 'organizeralexandreschmitt', limit: 11)
+        response = subject.call(:basic_pages, :index, site_slug: 'organizeralexandreschmitt', limit: 11)
         expect(response['status_code']).to eq(200)
         response['results'].each do |result|
           expect(result['site_slug']).to eq('organizeralexandreschmitt')
@@ -68,7 +74,7 @@ describe NationBuilder::Client do
       }
 
       response = VCR.use_cassette('parametered_post') do
-        client.call(:people, :create, params)
+        subject.call(:people, :create, params)
       end
 
       expect(response['status_code']).to eq(201)
@@ -87,11 +93,11 @@ describe NationBuilder::Client do
           }
         }
 
-        expect(client).to receive(:perform_request_with_retries) do |_, _, request_args|
+        expect(subject).to receive(:perform_request_with_retries) do |_, _, request_args|
           expect(request_args[:query][:fire_webhooks]).to be_falsey
         end
 
-        client.call(:people, :create, params)
+        subject.call(:people, :create, params)
       end
 
       it 'should not be included if not specified' do
@@ -103,11 +109,11 @@ describe NationBuilder::Client do
           }
         }
 
-        expect(client).to receive(:perform_request_with_retries) do |_, _, request_args|
+        expect(subject).to receive(:perform_request_with_retries) do |_, _, request_args|
           expect(request_args[:query].include?(:fire_webhooks)).to be_falsey
         end
 
-        client.call(:people, :create, params)
+        subject.call(:people, :create, params)
       end
 
     end
@@ -118,7 +124,7 @@ describe NationBuilder::Client do
       }
 
       response = VCR.use_cassette('delete') do
-        client.call(:people, :destroy, params)
+        subject.call(:people, :destroy, params)
       end
 
       expect(response).to eq(true)
@@ -128,35 +134,35 @@ describe NationBuilder::Client do
   describe '#classify_response_error' do
     it 'should account for rate limits' do
       response = double(code: 429, body: 'rate limiting')
-      expect(client.classify_response_error(response).class).
+      expect(subject.classify_response_error(response).class).
         to eq(NationBuilder::RateLimitedError)
     end
     it 'should account for client errors' do
       response = double(code: 404, body: '404ing')
-      expect(client.classify_response_error(response).class).
+      expect(subject.classify_response_error(response).class).
         to eq(NationBuilder::ClientError)
     end
     it 'should account for client errors' do
       response = double(code: 500, body: '500ing')
-      expect(client.classify_response_error(response).class).
+      expect(subject.classify_response_error(response).class).
         to eq(NationBuilder::ServerError)
     end
   end
 
   describe '#perform_request_with_retries' do
-    it 'should raise non-rate limiting execeptions' do
-      expect(HTTPClient).to receive(:send)
-      expect(client).to receive(:parse_response_body) { raise StandardError.new('boom') }
+    it 'should re-raise non-rate limiting execeptions' do
+      expect(http_client).to receive(:send)
+      expect(subject).to receive(:parse_response_body) { raise StandardError.new('boom') }
       expect do
-        client.perform_request_with_retries(nil, nil, nil)
-      end.to raise_error
+        subject.perform_request_with_retries(nil, nil, nil)
+      end.to raise_error(StandardError)
     end
 
     it 'should return a response if the rate limit is eventually dropped' do
-      expect(HTTPClient).to receive(:send).twice
+      expect(http_client).to receive(:send).twice
       expect(Kernel).to receive(:sleep)
 
-      allow(client).to receive(:parse_response_body) do
+      allow(subject).to receive(:parse_response_body) do
         unless @count
           @count ||= 0
         else
@@ -169,21 +175,34 @@ describe NationBuilder::Client do
       end
 
       expect do
-        client.perform_request_with_retries(nil, nil, nil)
+        subject.perform_request_with_retries(nil, nil, nil)
       end.to_not raise_error
     end
 
     it 'on the last retry, it should reraise the rate limiting exception ' do
-      expect(HTTPClient).to receive(:send).twice
+      expect(http_client).to receive(:send).twice
       expect(Kernel).to receive(:sleep).twice
 
-      allow(client).to receive(:parse_response_body) do
+      allow(subject).to receive(:parse_response_body) do
         raise NationBuilder::RateLimitedError.new
       end
 
       expect do
-        client.perform_request_with_retries(nil, nil, nil)
+        subject.perform_request_with_retries(nil, nil, nil)
       end.to raise_error(NationBuilder::RateLimitedError)
+    end
+  end
+
+  describe '#http_client' do
+    it 'exposes an HTTPClient instance' do
+      expect(subject.http_client).to be_an_instance_of HTTPClient
+    end
+
+    it 'memoizes the HTTPClient' do
+      h1 = subject.http_client
+      h2 = subject.http_client
+
+      expect(h1).to eq(h2)
     end
   end
 end


### PR DESCRIPTION
I've been trying to move my project from my own hand-rolled calls to NationBuilder to using the official client, but have found it difficult to inspect the traffic to figure out my bugs and mocks. Figured it would be helpful to let the programmer see the internal HTTPClient object so that they could turn on debugging or any other options they need for their environment.

Main use case for this PR is to turn on debugging so we can see what's
going between us and NationBuilder. However there are several options
that can be set on the object to tweak proxy and connection settings.

Also made some small changes to the test in order to make it easier to
grok. I moved the `NationBuilder::Client` object to use `subject` so it was
more clear when we're talking about the subject of the test (which is a
client) rather than the mocked `HTTPClient` client.
