### PR TITLE
Apply the same retry logic to timeouts

### DIFF
--- a/lib/nationbuilder/client.rb
+++ b/lib/nationbuilder/client.rb
@@ -84,7 +84,7 @@ class NationBuilder::Client
       begin
         raw_response = @http_client.send(method, url, request_args)
         parsed_response = parse_response_body(raw_response)
-      rescue NationBuilder::RateLimitedError => e
+      rescue HTTPClient::TimeoutError, NationBuilder::RateLimitedError => e
         exception_to_reraise = e
         Kernel.sleep(RETRY_DELAY * 2**i)
       rescue => e


### PR DESCRIPTION
I have noticed I'll sometimes get errors from NationBuilder that quickly
disappear. Use the same rate limiting logic to retry if there's a
connection problem.

Also simplify a related test using rspec mock functionality rather than
a loop.