### PR TITLE
lib/nationbuilder: include response object in errors

### DIFF
--- a/lib/nationbuilder/client.rb
+++ b/lib/nationbuilder/client.rb
@@ -116,11 +116,11 @@ class NationBuilder::Client
   def classify_response_error(response)
     case
     when response.code == 429
-      NationBuilder::RateLimitedError.new(response.body)
+      NationBuilder::RateLimitedError.new(response)
     when response.code.to_s.start_with?('4')
-      NationBuilder::ClientError.new(response.body)
+      NationBuilder::ClientError.new(response)
     when response.code.to_s.start_with?('5')
-      NationBuilder::ServerError.new(response.body)
+      NationBuilder::ServerError.new(response)
     end
   end
 

--- a/lib/nationbuilder/errors.rb
+++ b/lib/nationbuilder/errors.rb
@@ -1,6 +1,15 @@
 module NationBuilder
   class BaseError < StandardError; end
-  class ServerError < BaseError; end
-  class ClientError < BaseError; end
+
+  class ResponseError < BaseError
+    attr_reader :response
+    def initialize(response = nil)
+      super(response ? response.body : nil)
+      @response = response
+    end
+  end
+
+  class ServerError < ResponseError; end
+  class ClientError < ResponseError; end
   class RateLimitedError < ClientError; end
 end


### PR DESCRIPTION
This commit provides users with access to HTTP response objects
when the NationBuilder client encounters an error. Among other
things, this allows applications to respond intelligently to
different status codes. For example, checking for a 401 status
code can indicate to the host application that an access token
has expired or is otherwise invalid.

This commit is purely additive. Other than extending the error
objects with a `response` accessor, there should be no other
side effects.

Affected classes:

- ServerError
- ClientError
- RateLimitedError