### PR TITLE
Ensure setting the last response on the client for all requests

### DIFF
--- a/lib/nationbuilder/client.rb
+++ b/lib/nationbuilder/client.rb
@@ -92,6 +92,8 @@ class NationBuilder::Client
       else
         exception_to_reraise = nil
         break
+      ensure
+        set_response(raw_response)
       end
     end
 
@@ -100,7 +102,6 @@ class NationBuilder::Client
       raise exception_to_reraise
     end
 
-    set_response(raw_response)
     parsed_response
   end
 

--- a/lib/nationbuilder/client.rb
+++ b/lib/nationbuilder/client.rb
@@ -133,7 +133,7 @@ class NationBuilder::Client
       return true
     end
 
-    parsed_body(response.body).merge('status_code' => response.code)
+    parsed_body(response.body)
   end
 
   def print_all_descriptions

--- a/spec/fixtures/errored_get.yml
+++ b/spec/fixtures/errored_get.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/people/0?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.7.0.1, ruby 2.4.0 (2016-12-24))
+      Accept:
+      - application/json
+      Date:
+      - Fri, 24 Mar 2017 18:38:21 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Content-Type:
+      - application/json; charset=utf-8
+      Nation-Ratelimit-Limit:
+      - '999999'
+      Nation-Ratelimit-Remaining:
+      - '999999'
+      Nation-Ratelimit-Reset:
+      - '1490400000'
+      Status:
+      - 404 Not Found
+      X-Frame-Options:
+      - ALLOWALL
+      X-Powered-By:
+      - Phusion Passenger Enterprise 5.0.28
+      X-Pulse-Approved:
+      - 'true'
+      X-Rack-Cache:
+      - miss
+      X-Ratelimit-Limit:
+      - 10s
+      X-Ratelimit-Remaining:
+      - '99'
+      X-Ratelimit-Reset:
+      - '1490380712'
+      X-Request-Id:
+      - 9f507eed-89c0-4d40-9e91-25726a5aa197
+      X-Runtime:
+      - '0.082110'
+      Content-Length:
+      - '49'
+      Expires:
+      - Fri, 24 Mar 2017 18:38:22 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 24 Mar 2017 18:38:22 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _cookies_enabled=1490380702; path=/
+    body:
+      encoding: UTF-8
+      string: '{"code":"not_found","message":"Record not found"}'
+    http_version:
+  recorded_at: Fri, 24 Mar 2017 18:38:22 GMT
+recorded_with: VCR 2.9.3

--- a/spec/lib/nationbuilder/client_spec.rb
+++ b/spec/lib/nationbuilder/client_spec.rb
@@ -87,6 +87,17 @@ describe NationBuilder::Client do
       expect(response['person']['first_name']).to eq('Bob')
     end
 
+    context 'errored request' do
+      it 'sets the response on the client' do
+        VCR.use_cassette('errored_get') do
+          expect do
+            client.call(:people, :show, id: 0)
+          end.to raise_error(NationBuilder::ClientError)
+          expect(client.response.status).to eq(404)
+        end
+      end
+    end
+
     context 'fire_webhooks' do
 
       it 'should disable webhooks' do

--- a/spec/lib/nationbuilder/client_spec.rb
+++ b/spec/lib/nationbuilder/client_spec.rb
@@ -63,7 +63,7 @@ describe NationBuilder::Client do
     it 'should handle a parametered GET' do
       VCR.use_cassette('parametered_get') do
         response = client.call(:basic_pages, :index, site_slug: 'organizeralexandreschmitt', limit: 11)
-        expect(response['status_code']).to eq(200)
+        expect(client.response.status).to eq(200)
         response['results'].each do |result|
           expect(result['site_slug']).to eq('organizeralexandreschmitt')
         end
@@ -83,7 +83,7 @@ describe NationBuilder::Client do
         client.call(:people, :create, params)
       end
 
-      expect(response['status_code']).to eq(201)
+      expect(client.response.status).to eq(201)
       expect(response['person']['first_name']).to eq('Bob')
     end
 


### PR DESCRIPTION
In cases of requests where an error is raised, the `response` fails to get set on the `client` as it does in successful requests. This can lead to inconsistencies (ex. checking the `response ` on the client after an error will return the response from the last success) and prevent insight into the last response when diagnosing errors (which led to the proposed change in #39).

This change ensures that we're setting the response on the `client` for all requests made (which look to have been [desired behavior](https://github.com/nationbuilder/nationbuilder-rb/commit/825dbc7253c5d64fda8a020438ca175e02addca6#commitcomment-9771872) since [it was added](https://github.com/nationbuilder/nationbuilder-rb/commit/1a8773d0dcb8243ea85ba6cd39156aa1661e3ea5)), so it should more reliably return the response from the last client request as well as be accessible in case of errors.

Since the response is available via the client following a request, 7275740 removes having that added to the parsed response as well (added in #27)

@jeffomatic

cc: @bradb