### PR TITLE
Update query params to fix server error when searching people by custom fields

### DIFF
--- a/lib/nationbuilder.rb
+++ b/lib/nationbuilder.rb
@@ -7,6 +7,7 @@ require 'uri'
 module NationBuilder; end
 
 require 'nationbuilder/version'
+require 'nationbuilder/utils'
 require 'nationbuilder/client'
 require 'nationbuilder/endpoint'
 require 'nationbuilder/method'

--- a/lib/nationbuilder/client.rb
+++ b/lib/nationbuilder/client.rb
@@ -54,7 +54,7 @@ class NationBuilder::Client
     }
 
     if method == :get
-      request_args[:query].merge!(body)
+      request_args[:query].merge!(NationBuilder::Utils::QueryParams.encode(body))
     else
       body[:access_token] = @api_key
       if !body[:fire_webhooks].nil?

--- a/lib/nationbuilder/utils.rb
+++ b/lib/nationbuilder/utils.rb
@@ -1,0 +1,22 @@
+module NationBuilder::Utils
+  module QueryParams
+    module_function
+
+    def encode(value, key = nil, output = {})
+      case value
+      when Hash  then value.each { |k, v| encode(v, append_key(key, k), output) }
+      when Array then value.each { |v|    encode(v, "#{key}[]", output) }
+      when nil   then ''
+      else
+        output[key] = value
+      end
+      output
+    end
+
+    def append_key(root_key, key)
+      root_key.nil? ? "#{key}" : "#{root_key}[#{key}]"
+    end
+
+    private_class_method :append_key
+  end
+end

--- a/spec/fixtures/paginated_get.yml
+++ b/spec/fixtures/paginated_get.yml
@@ -1,0 +1,93 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3&limit=11
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.7.0.1, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - application/json
+      Date:
+      - Mon, 29 Oct 2018 20:22:11 GMT
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"c4a76aff76deb723dd693efc38070f0b-gzip"
+      Nation-Ratelimit-Limit:
+      - '999999'
+      Nation-Ratelimit-Remaining:
+      - '999999'
+      Nation-Ratelimit-Reset:
+      - '1540857600'
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - ALLOWALL
+      X-Middleware-Start:
+      - t=1540844531694805
+      X-Powered-By:
+      - Phusion Passenger Enterprise 5.0.28
+      X-Pulse-Approved:
+      - 'true'
+      X-Rack-Cache:
+      - miss
+      X-Ratelimit-Limit:
+      - 10s
+      X-Ratelimit-Remaining:
+      - '99'
+      X-Ratelimit-Reset:
+      - '1540844541'
+      X-Request-Id:
+      - c8499932-9d8c-4226-8072-ffc476c40bee
+      X-Runtime:
+      - '0.126811'
+      X-Served-By:
+      - api10
+      Content-Length:
+      - '3187'
+      Expires:
+      - Mon, 29 Oct 2018 20:22:11 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 29 Oct 2018 20:22:11 GMT
+      Connection:
+      - keep-alive
+      Use-Proxy:
+      - 'True'
+    body:
+      encoding: UTF-8
+      string: '{"results":[{"slug":"basic_23","path":"/basic_23","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        23","headline":"Basic 23","title":"Basic 23 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":121,"content":null},{"slug":"basic_22","path":"/basic_22","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        22","headline":"Basic 22","title":"Basic 22 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":120,"content":null},{"slug":"basic_21","path":"/basic_21","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        21","headline":"Basic 21","title":"Basic 21 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":119,"content":null},{"slug":"basic_20","path":"/basic_20","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        20","headline":"Basic 20","title":"Basic 20 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":118,"content":null},{"slug":"basic_19","path":"/basic_19","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        19","headline":"Basic 19","title":"Basic 19 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":117,"content":null},{"slug":"basic_18","path":"/basic_18","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        18","headline":"Basic 18","title":"Basic 18 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":116,"content":null},{"slug":"basic_17","path":"/basic_17","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        17","headline":"Basic 17","title":"Basic 17 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":115,"content":null},{"slug":"basic_16","path":"/basic_16","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        16","headline":"Basic 16","title":"Basic 16 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":114,"content":null},{"slug":"basic_15","path":"/basic_15","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        15","headline":"Basic 15","title":"Basic 15 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":113,"content":null},{"slug":"basic_14","path":"/basic_14","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        14","headline":"Basic 14","title":"Basic 14 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":112,"content":null},{"slug":"basic_13","path":"/basic_13","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
+        13","headline":"Basic 13","title":"Basic 13 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":111,"content":null}],"next":"/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?__nonce=5eanepvJ8zJ9uDq_l3Qw5g\u0026__token=APSDi6opdU3_R5Mx-Pt1r74sisBBZSGis7hF0Ky3u5ZB\u0026limit=11","prev":null}'
+    http_version:
+  recorded_at: Mon, 29 Oct 2018 20:22:11 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/parametered_get.yml
+++ b/spec/fixtures/parametered_get.yml
@@ -2,17 +2,17 @@
 http_interactions:
 - request:
     method: get
-    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3&limit=11
+    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/people/search?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3&custom_values%5Bgraduation_year%5D=2008&first_name=Alex&limit=2
     body:
       encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.7.0.1, ruby 2.1.6 (2015-04-13))
+      - HTTPClient/1.0 (2.7.0.1, ruby 2.5.1 (2018-03-29))
       Accept:
       - application/json
       Date:
-      - Wed, 23 Nov 2016 19:16:54 GMT
+      - Mon, 29 Oct 2018 20:20:03 GMT
       Content-Type:
       - application/json
   response:
@@ -20,18 +20,18 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - Apache/2.4.7 (Ubuntu)
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"709a1f317fbb097ab1029fcba5e8f8c1-gzip"
+      - W/"22dbb824b3d20ee8ecc94045fc22785f-gzip"
       Nation-Ratelimit-Limit:
       - '999999'
       Nation-Ratelimit-Remaining:
       - '999999'
       Nation-Ratelimit-Reset:
-      - '1479945600'
+      - '1540857600'
+      Server:
+      - Apache/2.4.7 (Ubuntu)
       Status:
       - 200 OK
       Vary:
@@ -39,7 +39,9 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
-      - SAMEORIGIN
+      - ALLOWALL
+      X-Middleware-Start:
+      - t=1540844404429755
       X-Powered-By:
       - Phusion Passenger Enterprise 5.0.28
       X-Pulse-Approved:
@@ -49,43 +51,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - 10s
       X-Ratelimit-Remaining:
-      - '98'
+      - '99'
       X-Ratelimit-Reset:
-      - '1479928618'
+      - '1540844414'
       X-Request-Id:
-      - 2b52691c-8ad0-4791-9baa-e74ee75913d9
+      - 510effc7-749c-43e5-ab66-713f36aa8e1e
       X-Runtime:
-      - '0.127156'
-      X-Xss-Protection:
-      - 1; mode=block
+      - '0.132674'
+      X-Served-By:
+      - api11
       Content-Length:
-      - '3187'
+      - '2785'
       Expires:
-      - Wed, 23 Nov 2016 19:16:54 GMT
+      - Mon, 29 Oct 2018 20:20:04 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
       Date:
-      - Wed, 23 Nov 2016 19:16:54 GMT
+      - Mon, 29 Oct 2018 20:20:04 GMT
       Connection:
       - keep-alive
-      Set-Cookie:
-      - _cookies_enabled=1479928614; path=/
+      Use-Proxy:
+      - 'True'
     body:
       encoding: UTF-8
-      string: '{"results":[{"slug":"basic_23","path":"/basic_23","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        23","headline":"Basic 23","title":"Basic 23 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":121,"content":null},{"slug":"basic_22","path":"/basic_22","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        22","headline":"Basic 22","title":"Basic 22 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":120,"content":null},{"slug":"basic_21","path":"/basic_21","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        21","headline":"Basic 21","title":"Basic 21 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":119,"content":null},{"slug":"basic_20","path":"/basic_20","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        20","headline":"Basic 20","title":"Basic 20 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":118,"content":null},{"slug":"basic_19","path":"/basic_19","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        19","headline":"Basic 19","title":"Basic 19 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":117,"content":null},{"slug":"basic_18","path":"/basic_18","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        18","headline":"Basic 18","title":"Basic 18 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":116,"content":null},{"slug":"basic_17","path":"/basic_17","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        17","headline":"Basic 17","title":"Basic 17 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":115,"content":null},{"slug":"basic_16","path":"/basic_16","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        16","headline":"Basic 16","title":"Basic 16 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":114,"content":null},{"slug":"basic_15","path":"/basic_15","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        15","headline":"Basic 15","title":"Basic 15 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":113,"content":null},{"slug":"basic_14","path":"/basic_14","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        14","headline":"Basic 14","title":"Basic 14 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":112,"content":null},{"slug":"basic_13","path":"/basic_13","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        13","headline":"Basic 13","title":"Basic 13 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":111,"content":null}],"next":"/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?__nonce=rRTZyJ1Q1DTwfydcPslJKQ\u0026__token=ADkN8CRnANjq04HdDFL4YXS8ACHTkhch-5eyGVn-SpAN\u0026limit=11","prev":null}'
-    http_version: 
-  recorded_at: Wed, 23 Nov 2016 19:16:54 GMT
+      string: '{"results":[{"birthdate":null,"city_district":null,"civicrm_id":null,"county_district":null,"county_file_id":null,"created_at":"2018-10-29T19:09:52Z","datatrust_id":null,"do_not_call":false,"do_not_contact":false,"dw_id":null,"email":"alexdoe@exampleschool.edu","email_opt_in":true,"employer":"","external_id":null,"federal_district":null,"fire_district":null,"first_name":"Alex","has_facebook":false,"id":352989,"is_twitter_follower":false,"is_volunteer":false,"judicial_district":null,"labour_region":null,"last_name":"Doe","linkedin_id":null,"mobile":"","mobile_opt_in":true,"middle_name":"","nbec_guid":null,"ngp_id":null,"note":"","occupation":"","party":"","pf_strat_id":null,"phone":"","precinct_id":null,"primary_address":null,"profile_image_url_ssl":"https://d3n8a8pro7vhmx.cloudfront.net/assets/notifier/profile-avatar.png","recruiter_id":null,"rnc_id":null,"rnc_regid":null,"salesforce_id":null,"school_district":null,"school_sub_district":null,"sex":"","signup_type":0,"state_file_id":null,"state_lower_district":null,"state_upper_district":null,"support_level":null,"supranational_district":null,"tags":[],"twitter_id":null,"twitter_name":null,"updated_at":"2018-10-29T19:10:05Z","van_id":null,"village_district":null,"ward":null,"work_phone_number":"","graduation_year":2008.0},{"birthdate":null,"city_district":null,"civicrm_id":null,"county_district":null,"county_file_id":null,"created_at":"2018-05-31T00:07:29Z","datatrust_id":null,"do_not_call":false,"do_not_contact":false,"dw_id":null,"email":"alex@exampleschool.edu","email_opt_in":true,"employer":"","external_id":null,"federal_district":null,"fire_district":null,"first_name":"Alex","has_facebook":false,"id":352955,"is_twitter_follower":false,"is_volunteer":false,"judicial_district":null,"labour_region":null,"last_name":"Smith","linkedin_id":null,"mobile":"","mobile_opt_in":true,"middle_name":"","nbec_guid":null,"ngp_id":null,"note":null,"occupation":"","party":"","pf_strat_id":null,"phone":"","precinct_id":null,"primary_address":null,"profile_image_url_ssl":"https://d3n8a8pro7vhmx.cloudfront.net/assets/notifier/profile-avatar.png","recruiter_id":null,"rnc_id":null,"rnc_regid":null,"salesforce_id":null,"school_district":null,"school_sub_district":null,"sex":"","signup_type":0,"state_file_id":null,"state_lower_district":null,"state_upper_district":null,"support_level":null,"supranational_district":null,"tags":[],"twitter_id":null,"twitter_name":null,"updated_at":"2018-10-29T19:09:34Z","van_id":null,"village_district":null,"ward":null,"work_phone_number":"","graduation_year":2008.0}],"next":"/api/v1/people/search?__nonce=Z95uFNEYek3JMk7aZWYL3A\u0026__token=AFwi3WBpELaAwUEjhPFiVsRvUjLoIfXrD-3u5Iu2sJah\u0026custom_values%5Bgraduation_year%5D=2008\u0026first_name=Alex\u0026limit=2","prev":null}'
+    http_version:
+  recorded_at: Mon, 29 Oct 2018 20:20:04 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lib/nationbuilder/client_spec.rb
+++ b/spec/lib/nationbuilder/client_spec.rb
@@ -62,11 +62,9 @@ describe NationBuilder::Client do
 
     it 'should handle a parametered GET' do
       VCR.use_cassette('parametered_get') do
-        response = client.call(:basic_pages, :index, site_slug: 'organizeralexandreschmitt', limit: 11)
+        response = client.call(:people, :search, first_name: "Alex", custom_values: { graduation_year: "2008" }, limit: 2)
         expect(client.response.status).to eq(200)
-        response['results'].each do |result|
-          expect(result['site_slug']).to eq('organizeralexandreschmitt')
-        end
+        expect(response['results'].count).to eq(2)
       end
     end
 

--- a/spec/lib/nationbuilder/paginator_spec.rb
+++ b/spec/lib/nationbuilder/paginator_spec.rb
@@ -7,7 +7,7 @@ describe NationBuilder::Paginator do
                               '03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3')
   end
   let(:response) do
-    VCR.use_cassette('parametered_get') do
+    VCR.use_cassette('paginated_get') do
       client.call(:basic_pages, :index, site_slug: 'organizeralexandreschmitt', limit: 11)
     end
   end

--- a/spec/lib/nationbuilder/utils_spec.rb
+++ b/spec/lib/nationbuilder/utils_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe NationBuilder::Utils::QueryParams do
+  describe ".encode" do
+    context "nested hash" do
+      it "formats to proper url params hash" do
+        expect(
+          described_class.encode({ first: { second: { third: "value" } } })
+        ).to eq({ "first[second][third]" => "value" })
+      end
+    end
+
+    context "array" do
+      it "formats to proper url params hash" do
+        expect(described_class.encode(["tag"])).to eq({ "[]" => "tag" })
+      end
+    end
+
+    context "nil" do
+      it "formats to proper url params hash" do
+        expect(described_class.encode(nil)).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/nationbuilder/nationbuilder-rb/issues/44

Per https://nationbuilder.com/people_api#search, the `people#search` endpoint supports searching by custom fields. However, using the client returns a 500 as the params are not being encoded as the server expects.

This adds a `Utils` module to address this to avoid introducing additional dependencies (this is included in Rack in `build_nested_query`, and ActiveSupport in Rails in `Hash.to_query`)

For context, several approaches are discussed in this [StackOverflow](https://stackoverflow.com/questions/798710/ruby-how-to-turn-a-hash-into-http-parameters) - this follows what was proposed in [this blog post](https://mensfeld.pl/2012/01/converting-nested-hash-into-http-url-params-hash-version-in-ruby/), similar to the approach in the [QueryParam gem](https://github.com/simen/queryparams).