### PR TITLE
Pass access token in headers instead of as a query param

### DIFF
--- a/lib/nationbuilder/client.rb
+++ b/lib/nationbuilder/client.rb
@@ -45,18 +45,16 @@ class NationBuilder::Client
 
     request_args = {
       header: {
-        'Accept' => 'application/json',
-        'Content-Type' => 'application/json'
+        'Accept'        => 'application/json',
+        'Content-Type'  => 'application/json',
+        'Authorization' => "Bearer #{@api_key}"
       },
-      query: {
-        access_token: @api_key
-      }
+      query: {}
     }
 
     if method == :get
       request_args[:query].merge!(NationBuilder::Utils::QueryParams.encode(body))
     else
-      body[:access_token] = @api_key
       if !body[:fire_webhooks].nil?
         request_args[:query][:fire_webhooks] = body[:fire_webhooks]
       end

--- a/lib/nationbuilder/paginator.rb
+++ b/lib/nationbuilder/paginator.rb
@@ -14,7 +14,7 @@ class NationBuilder::Paginator
     define_method(:"#{page_type}") do |call_body = {}|
       return nil unless send(:"#{page_type}?")
       path = send(:"#{page_type}?").split('/api/v1').last
-      call_body[:limit] ||= CGI.parse(path)['limit']
+      call_body[:limit] ||= CGI.parse(path)['limit'][0]
       results = @client.raw_call(path, :get, call_body)
       return self.class.new(@client, results)
     end

--- a/spec/fixtures/delete.yml
+++ b/spec/fixtures/delete.yml
@@ -2,38 +2,42 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/people/278881?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
+    uri: https://testnation.nationbuilder.com/api/v1/people/278881
     body:
       encoding: UTF-8
-      string: '{"access_token":"03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3"}'
+      string: "{}"
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.7.0.1, ruby 2.1.6 (2015-04-13))
+      - HTTPClient/1.0 (2.7.0.1, ruby 2.5.1 (2018-03-29))
       Accept:
       - application/json
       Date:
-      - Wed, 23 Nov 2016 19:16:47 GMT
+      - Tue, 30 Oct 2018 20:21:54 GMT
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer 03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
   response:
     status:
       code: 204
       message: No Content
     headers:
-      Server:
-      - Apache/2.4.7 (Ubuntu)
       Nation-Ratelimit-Limit:
       - '999999'
       Nation-Ratelimit-Remaining:
       - '999999'
       Nation-Ratelimit-Reset:
-      - '1479945600'
+      - '1540944000'
+      Server:
+      - Apache/2.4.7 (Ubuntu)
       Status:
       - 204 No Content
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
-      - SAMEORIGIN
+      - ALLOWALL
+      X-Middleware-Start:
+      - t=1540930915181995
       X-Powered-By:
       - Phusion Passenger Enterprise 5.0.28
       X-Pulse-Approved:
@@ -45,30 +49,28 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '99'
       X-Ratelimit-Reset:
-      - '1479928618'
+      - '1540930925'
       X-Request-Id:
-      - 48920c47-e280-436b-9a98-36fa47402ce9
+      - eabac74f-2db5-4709-978c-bbf60720df1e
       X-Runtime:
-      - '1.202383'
-      X-Xss-Protection:
-      - 1; mode=block
-      Content-Length:
-      - '0'
+      - '1.301545'
+      X-Served-By:
+      - api11
       Expires:
-      - Wed, 23 Nov 2016 19:16:49 GMT
+      - Tue, 30 Oct 2018 20:21:56 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
       Date:
-      - Wed, 23 Nov 2016 19:16:49 GMT
+      - Tue, 30 Oct 2018 20:21:56 GMT
       Connection:
       - keep-alive
-      Set-Cookie:
-      - _cookies_enabled=1479928609; path=/
+      Use-Proxy:
+      - 'True'
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
-  recorded_at: Wed, 23 Nov 2016 19:16:49 GMT
+    http_version:
+  recorded_at: Tue, 30 Oct 2018 20:21:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/errored_get.yml
+++ b/spec/fixtures/errored_get.yml
@@ -2,26 +2,26 @@
 http_interactions:
 - request:
     method: get
-    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/people/0?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
+    uri: https://testnation.nationbuilder.com/api/v1/people/0
     body:
       encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.7.0.1, ruby 2.4.0 (2016-12-24))
+      - HTTPClient/1.0 (2.7.0.1, ruby 2.5.1 (2018-03-29))
       Accept:
       - application/json
       Date:
-      - Fri, 24 Mar 2017 18:38:21 GMT
+      - Tue, 30 Oct 2018 20:20:39 GMT
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer 03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
   response:
     status:
       code: 404
       message: Not Found
     headers:
-      Server:
-      - Apache/2.4.7 (Ubuntu)
       Content-Type:
       - application/json; charset=utf-8
       Nation-Ratelimit-Limit:
@@ -29,11 +29,17 @@ http_interactions:
       Nation-Ratelimit-Remaining:
       - '999999'
       Nation-Ratelimit-Reset:
-      - '1490400000'
+      - '1540944000'
+      Server:
+      - Apache/2.4.7 (Ubuntu)
       Status:
       - 404 Not Found
+      X-Content-Type-Options:
+      - nosniff
       X-Frame-Options:
       - ALLOWALL
+      X-Middleware-Start:
+      - t=1540930839625416
       X-Powered-By:
       - Phusion Passenger Enterprise 5.0.28
       X-Pulse-Approved:
@@ -43,30 +49,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - 10s
       X-Ratelimit-Remaining:
-      - '99'
+      - '98'
       X-Ratelimit-Reset:
-      - '1490380712'
+      - '1540930848'
       X-Request-Id:
-      - 9f507eed-89c0-4d40-9e91-25726a5aa197
+      - b89dc2fd-2a92-425c-9c60-228e3bf634c9
       X-Runtime:
-      - '0.082110'
+      - '0.067800'
+      X-Served-By:
+      - api12
       Content-Length:
       - '49'
       Expires:
-      - Fri, 24 Mar 2017 18:38:22 GMT
+      - Tue, 30 Oct 2018 20:20:39 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
       Date:
-      - Fri, 24 Mar 2017 18:38:22 GMT
+      - Tue, 30 Oct 2018 20:20:39 GMT
       Connection:
       - keep-alive
-      Set-Cookie:
-      - _cookies_enabled=1490380702; path=/
+      Use-Proxy:
+      - 'True'
     body:
       encoding: UTF-8
       string: '{"code":"not_found","message":"Record not found"}'
-    http_version:
-  recorded_at: Fri, 24 Mar 2017 18:38:22 GMT
+    http_version: 
+  recorded_at: Tue, 30 Oct 2018 20:20:39 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/paginated_get.yml
+++ b/spec/fixtures/paginated_get.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3&limit=11
+    uri: https://testnation.nationbuilder.com/api/v1/sites/testsite/pages/basic_pages?limit=11
     body:
       encoding: UTF-8
       string: ''
@@ -12,9 +12,11 @@ http_interactions:
       Accept:
       - application/json
       Date:
-      - Mon, 29 Oct 2018 20:22:11 GMT
+      - Tue, 30 Oct 2018 20:20:39 GMT
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer 03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
   response:
     status:
       code: 200
@@ -23,13 +25,13 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"c4a76aff76deb723dd693efc38070f0b-gzip"
+      - W/"a7398a0ece988aab15f07997d6eeb23a-gzip"
       Nation-Ratelimit-Limit:
       - '999999'
       Nation-Ratelimit-Remaining:
       - '999999'
       Nation-Ratelimit-Reset:
-      - '1540857600'
+      - '1540944000'
       Server:
       - Apache/2.4.7 (Ubuntu)
       Status:
@@ -41,7 +43,7 @@ http_interactions:
       X-Frame-Options:
       - ALLOWALL
       X-Middleware-Start:
-      - t=1540844531694805
+      - t=1540930840130933
       X-Powered-By:
       - Phusion Passenger Enterprise 5.0.28
       X-Pulse-Approved:
@@ -51,43 +53,43 @@ http_interactions:
       X-Ratelimit-Limit:
       - 10s
       X-Ratelimit-Remaining:
-      - '99'
+      - '97'
       X-Ratelimit-Reset:
-      - '1540844541'
+      - '1540930848'
       X-Request-Id:
-      - c8499932-9d8c-4226-8072-ffc476c40bee
+      - 64295f87-393a-4385-b0f3-05812b75ad5b
       X-Runtime:
-      - '0.126811'
+      - '0.104447'
       X-Served-By:
-      - api10
+      - api13
       Content-Length:
       - '3187'
       Expires:
-      - Mon, 29 Oct 2018 20:22:11 GMT
+      - Tue, 30 Oct 2018 20:20:40 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
       Date:
-      - Mon, 29 Oct 2018 20:22:11 GMT
+      - Tue, 30 Oct 2018 20:20:40 GMT
       Connection:
       - keep-alive
       Use-Proxy:
       - 'True'
     body:
       encoding: UTF-8
-      string: '{"results":[{"slug":"basic_23","path":"/basic_23","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        23","headline":"Basic 23","title":"Basic 23 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":121,"content":null},{"slug":"basic_22","path":"/basic_22","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        22","headline":"Basic 22","title":"Basic 22 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":120,"content":null},{"slug":"basic_21","path":"/basic_21","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        21","headline":"Basic 21","title":"Basic 21 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":119,"content":null},{"slug":"basic_20","path":"/basic_20","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        20","headline":"Basic 20","title":"Basic 20 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":118,"content":null},{"slug":"basic_19","path":"/basic_19","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        19","headline":"Basic 19","title":"Basic 19 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":117,"content":null},{"slug":"basic_18","path":"/basic_18","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        18","headline":"Basic 18","title":"Basic 18 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":116,"content":null},{"slug":"basic_17","path":"/basic_17","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        17","headline":"Basic 17","title":"Basic 17 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":115,"content":null},{"slug":"basic_16","path":"/basic_16","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        16","headline":"Basic 16","title":"Basic 16 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":114,"content":null},{"slug":"basic_15","path":"/basic_15","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        15","headline":"Basic 15","title":"Basic 15 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":113,"content":null},{"slug":"basic_14","path":"/basic_14","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        14","headline":"Basic 14","title":"Basic 14 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":112,"content":null},{"slug":"basic_13","path":"/basic_13","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        13","headline":"Basic 13","title":"Basic 13 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":111,"content":null}],"next":"/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?__nonce=5eanepvJ8zJ9uDq_l3Qw5g\u0026__token=APSDi6opdU3_R5Mx-Pt1r74sisBBZSGis7hF0Ky3u5ZB\u0026limit=11","prev":null}'
+      string: '{"results":[{"slug":"basic_23","path":"/basic_23","status":"unlisted","site_slug":"testsite","name":"Basic
+        23","headline":"Basic 23","title":"Basic 23 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":121,"content":null},{"slug":"basic_22","path":"/basic_22","status":"unlisted","site_slug":"testsite","name":"Basic
+        22","headline":"Basic 22","title":"Basic 22 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":120,"content":null},{"slug":"basic_21","path":"/basic_21","status":"unlisted","site_slug":"testsite","name":"Basic
+        21","headline":"Basic 21","title":"Basic 21 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":119,"content":null},{"slug":"basic_20","path":"/basic_20","status":"unlisted","site_slug":"testsite","name":"Basic
+        20","headline":"Basic 20","title":"Basic 20 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":118,"content":null},{"slug":"basic_19","path":"/basic_19","status":"unlisted","site_slug":"testsite","name":"Basic
+        19","headline":"Basic 19","title":"Basic 19 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":117,"content":null},{"slug":"basic_18","path":"/basic_18","status":"unlisted","site_slug":"testsite","name":"Basic
+        18","headline":"Basic 18","title":"Basic 18 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":116,"content":null},{"slug":"basic_17","path":"/basic_17","status":"unlisted","site_slug":"testsite","name":"Basic
+        17","headline":"Basic 17","title":"Basic 17 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":115,"content":null},{"slug":"basic_16","path":"/basic_16","status":"unlisted","site_slug":"testsite","name":"Basic
+        16","headline":"Basic 16","title":"Basic 16 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":114,"content":null},{"slug":"basic_15","path":"/basic_15","status":"unlisted","site_slug":"testsite","name":"Basic
+        15","headline":"Basic 15","title":"Basic 15 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":113,"content":null},{"slug":"basic_14","path":"/basic_14","status":"unlisted","site_slug":"testsite","name":"Basic
+        14","headline":"Basic 14","title":"Basic 14 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":112,"content":null},{"slug":"basic_13","path":"/basic_13","status":"unlisted","site_slug":"testsite","name":"Basic
+        13","headline":"Basic 13","title":"Basic 13 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":111,"content":null}],"next":"/api/v1/sites/testsite/pages/basic_pages?__nonce=Ked-9tttB9C4cKzeOcTGpQ\u0026__token=AIstYXYV_-i77Hdo8HcDDdBvt7l3HSo1FBm6CdgdouS6\u0026limit=11","prev":null}'
     http_version:
-  recorded_at: Mon, 29 Oct 2018 20:22:11 GMT
+  recorded_at: Tue, 30 Oct 2018 20:20:40 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/paginated_get_page2.yml
+++ b/spec/fixtures/paginated_get_page2.yml
@@ -2,36 +2,38 @@
 http_interactions:
 - request:
     method: get
-    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3&limit%5B%5D=11
+    uri: https://testnation.nationbuilder.com/api/v1/sites/testsite/pages/basic_pages?limit=11
     body:
       encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.7.0.1, ruby 2.1.6 (2015-04-13))
+      - HTTPClient/1.0 (2.7.0.1, ruby 2.5.1 (2018-03-29))
       Accept:
       - application/json
       Date:
-      - Wed, 23 Nov 2016 19:17:09 GMT
+      - Tue, 30 Oct 2018 20:31:16 GMT
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer 03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
   response:
     status:
       code: 200
       message: OK
     headers:
-      Server:
-      - Apache/2.4.7 (Ubuntu)
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"9140e46e19c9243629b7c008dacfb6e8-gzip"
+      - W/"ddf724d5fee593219690d48451493c0a-gzip"
       Nation-Ratelimit-Limit:
       - '999999'
       Nation-Ratelimit-Remaining:
       - '999999'
       Nation-Ratelimit-Reset:
-      - '1479945600'
+      - '1540944000'
+      Server:
+      - Apache/2.4.7 (Ubuntu)
       Status:
       - 200 OK
       Vary:
@@ -39,7 +41,9 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
-      - SAMEORIGIN
+      - ALLOWALL
+      X-Middleware-Start:
+      - t=1540931476975608
       X-Powered-By:
       - Phusion Passenger Enterprise 5.0.28
       X-Pulse-Approved:
@@ -51,41 +55,41 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '99'
       X-Ratelimit-Reset:
-      - '1479928639'
+      - '1540931486'
       X-Request-Id:
-      - 868ad7d0-3c07-4268-b4be-df06c825def6
+      - 9e24943a-0fee-4d2a-9db0-3dbcc0de43c9
       X-Runtime:
-      - '0.128563'
-      X-Xss-Protection:
-      - 1; mode=block
+      - '0.107058'
+      X-Served-By:
+      - api13
       Content-Length:
       - '3305'
       Expires:
-      - Wed, 23 Nov 2016 19:17:09 GMT
+      - Tue, 30 Oct 2018 20:31:17 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
       Date:
-      - Wed, 23 Nov 2016 19:17:09 GMT
+      - Tue, 30 Oct 2018 20:31:17 GMT
       Connection:
       - keep-alive
-      Set-Cookie:
-      - _cookies_enabled=1479928629; path=/
+      Use-Proxy:
+      - 'True'
     body:
       encoding: UTF-8
-      string: '{"results":[{"slug":"basic_12","path":"/basic_12","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        12","headline":"Basic 12","title":"Basic 12 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":110,"content":null},{"slug":"basic_11","path":"/basic_11","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        11","headline":"Basic 11","title":"Basic 11 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":109,"content":null},{"slug":"basic_10","path":"/basic_10","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        10","headline":"Basic 10","title":"Basic 10 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":108,"content":null},{"slug":"basic_9","path":"/basic_9","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        9","headline":"Basic 9","title":"Basic 9 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":107,"content":null},{"slug":"basic_8","path":"/basic_8","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        8","headline":"Basic 8","title":"Basic 8 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":106,"content":null},{"slug":"basic_7","path":"/basic_7","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        7","headline":"Basic 7","title":"Basic 7 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":105,"content":null},{"slug":"basic_6","path":"/basic_6","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        6","headline":"Basic 6","title":"Basic 6 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":104,"content":null},{"slug":"basic_5","path":"/basic_5","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        5","headline":"Basic 5","title":"Basic 5 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":103,"content":null},{"slug":"basic_4","path":"/basic_4","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        4","headline":"Basic 4","title":"Basic 4 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":102,"content":null},{"slug":"basic_3","path":"/basic_3","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        3","headline":"Basic 3","title":"Basic 3 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":101,"content":null},{"slug":"basic_2","path":"/basic_2","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        2","headline":"Basic 2","title":"Basic 2 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":100,"content":null}],"next":"/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?__nonce=YHteee9fl30rmKsPK-SEKA\u0026__token=ABqSQelwXnDULzDPylmk4BX8r4LjbRnMPuSjRZlbt-oB\u0026limit=11","prev":"/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?__nonce=Nojx3NZsAOdplehCbqrk2g\u0026__token=AMDXM18FNoA5qtdLoZo_Fr3WI6dZk64soOdeONMtNlKe\u0026limit=11"}'
-    http_version: 
-  recorded_at: Wed, 23 Nov 2016 19:17:09 GMT
+      string: '{"results":[{"slug":"basic_12","path":"/basic_12","status":"unlisted","site_slug":"testsite","name":"Basic
+        12","headline":"Basic 12","title":"Basic 12 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":110,"content":null},{"slug":"basic_11","path":"/basic_11","status":"unlisted","site_slug":"testsite","name":"Basic
+        11","headline":"Basic 11","title":"Basic 11 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":109,"content":null},{"slug":"basic_10","path":"/basic_10","status":"unlisted","site_slug":"testsite","name":"Basic
+        10","headline":"Basic 10","title":"Basic 10 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":108,"content":null},{"slug":"basic_9","path":"/basic_9","status":"unlisted","site_slug":"testsite","name":"Basic
+        9","headline":"Basic 9","title":"Basic 9 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":107,"content":null},{"slug":"basic_8","path":"/basic_8","status":"unlisted","site_slug":"testsite","name":"Basic
+        8","headline":"Basic 8","title":"Basic 8 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":106,"content":null},{"slug":"basic_7","path":"/basic_7","status":"unlisted","site_slug":"testsite","name":"Basic
+        7","headline":"Basic 7","title":"Basic 7 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":105,"content":null},{"slug":"basic_6","path":"/basic_6","status":"unlisted","site_slug":"testsite","name":"Basic
+        6","headline":"Basic 6","title":"Basic 6 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":104,"content":null},{"slug":"basic_5","path":"/basic_5","status":"unlisted","site_slug":"testsite","name":"Basic
+        5","headline":"Basic 5","title":"Basic 5 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":103,"content":null},{"slug":"basic_4","path":"/basic_4","status":"unlisted","site_slug":"testsite","name":"Basic
+        4","headline":"Basic 4","title":"Basic 4 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":102,"content":null},{"slug":"basic_3","path":"/basic_3","status":"unlisted","site_slug":"testsite","name":"Basic
+        3","headline":"Basic 3","title":"Basic 3 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":101,"content":null},{"slug":"basic_2","path":"/basic_2","status":"unlisted","site_slug":"testsite","name":"Basic
+        2","headline":"Basic 2","title":"Basic 2 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":100,"content":null}],"next":"/api/v1/sites/testsite/pages/basic_pages?__nonce=ZRk-hXBpoItRjub8-3Aq8Q\u0026__token=ALuHSEp6Pd95pwihMS5XHDeN1OeQ4VKfshkVbbd8NG60\u0026limit=11","prev":"/api/v1/sites/testsite/pages/basic_pages?__nonce=MNChF9JK8jg0QpBB0wGj3A\u0026__token=ACMtRFjLF7ntG_5qlV02ukrv6MfAsCKhqtXIgm-E4Awf\u0026limit=11"}'
+    http_version:
+  recorded_at: Tue, 30 Oct 2018 20:31:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/paginated_get_page2_with_limit.yml
+++ b/spec/fixtures/paginated_get_page2_with_limit.yml
@@ -2,36 +2,38 @@
 http_interactions:
 - request:
     method: get
-    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3&limit=5
+    uri: https://testnation.nationbuilder.com/api/v1/sites/testsite/pages/basic_pages?limit=5
     body:
       encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.7.0.1, ruby 2.1.6 (2015-04-13))
+      - HTTPClient/1.0 (2.7.0.1, ruby 2.5.1 (2018-03-29))
       Accept:
       - application/json
       Date:
-      - Wed, 23 Nov 2016 19:17:09 GMT
+      - Tue, 30 Oct 2018 20:31:20 GMT
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer 03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
   response:
     status:
       code: 200
       message: OK
     headers:
-      Server:
-      - Apache/2.4.7 (Ubuntu)
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"ae6cfb238c7ae115c9bb94a5f8fa4d88-gzip"
+      - W/"242c92633784576593dad1a16b0aa5b6-gzip"
       Nation-Ratelimit-Limit:
       - '999999'
       Nation-Ratelimit-Remaining:
       - '999999'
       Nation-Ratelimit-Reset:
-      - '1479945600'
+      - '1540944000'
+      Server:
+      - Apache/2.4.7 (Ubuntu)
       Status:
       - 200 OK
       Vary:
@@ -39,7 +41,9 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
-      - SAMEORIGIN
+      - ALLOWALL
+      X-Middleware-Start:
+      - t=1540931481020421
       X-Powered-By:
       - Phusion Passenger Enterprise 5.0.28
       X-Pulse-Approved:
@@ -49,37 +53,37 @@ http_interactions:
       X-Ratelimit-Limit:
       - 10s
       X-Ratelimit-Remaining:
-      - '97'
+      - '98'
       X-Ratelimit-Reset:
-      - '1479928639'
+      - '1540931486'
       X-Request-Id:
-      - e81a78f8-69b4-413d-ae80-e2321c796f02
+      - bf206535-96f2-42c3-a9a4-76f3d763ee5e
       X-Runtime:
-      - '0.081547'
-      X-Xss-Protection:
-      - 1; mode=block
+      - '0.122913'
+      X-Served-By:
+      - api11
       Content-Length:
       - '1701'
       Expires:
-      - Wed, 23 Nov 2016 19:17:10 GMT
+      - Tue, 30 Oct 2018 20:31:21 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
       Date:
-      - Wed, 23 Nov 2016 19:17:10 GMT
+      - Tue, 30 Oct 2018 20:31:21 GMT
       Connection:
       - keep-alive
-      Set-Cookie:
-      - _cookies_enabled=1479928630; path=/
+      Use-Proxy:
+      - 'True'
     body:
       encoding: UTF-8
-      string: '{"results":[{"slug":"basic_12","path":"/basic_12","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        12","headline":"Basic 12","title":"Basic 12 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":110,"content":null},{"slug":"basic_11","path":"/basic_11","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        11","headline":"Basic 11","title":"Basic 11 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":109,"content":null},{"slug":"basic_10","path":"/basic_10","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        10","headline":"Basic 10","title":"Basic 10 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":108,"content":null},{"slug":"basic_9","path":"/basic_9","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        9","headline":"Basic 9","title":"Basic 9 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":107,"content":null},{"slug":"basic_8","path":"/basic_8","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        8","headline":"Basic 8","title":"Basic 8 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":106,"content":null}],"next":"/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?__nonce=hjckzj_F5iPf5lfrG8BYKw\u0026__token=AOtncKrhUkSJTuXnTXsNM7ShamHbixIDNcnJ3zMVk3ob\u0026limit=5","prev":"/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?__nonce=MEaAhepTzsP3N1rirzlulA\u0026__token=AKRG10xG60JZdtnI5KaWzKd97xwkLMUGuCdULGAYZHo1\u0026limit=5"}'
-    http_version: 
-  recorded_at: Wed, 23 Nov 2016 19:17:10 GMT
+      string: '{"results":[{"slug":"basic_12","path":"/basic_12","status":"unlisted","site_slug":"testsite","name":"Basic
+        12","headline":"Basic 12","title":"Basic 12 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":110,"content":null},{"slug":"basic_11","path":"/basic_11","status":"unlisted","site_slug":"testsite","name":"Basic
+        11","headline":"Basic 11","title":"Basic 11 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":109,"content":null},{"slug":"basic_10","path":"/basic_10","status":"unlisted","site_slug":"testsite","name":"Basic
+        10","headline":"Basic 10","title":"Basic 10 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":108,"content":null},{"slug":"basic_9","path":"/basic_9","status":"unlisted","site_slug":"testsite","name":"Basic
+        9","headline":"Basic 9","title":"Basic 9 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":107,"content":null},{"slug":"basic_8","path":"/basic_8","status":"unlisted","site_slug":"testsite","name":"Basic
+        8","headline":"Basic 8","title":"Basic 8 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":106,"content":null}],"next":"/api/v1/sites/testsite/pages/basic_pages?__nonce=tnHZBeItEJEadJKW-lerRg\u0026__token=APRyDDzee5rn5zmkdWQbp-CoMuliTas2BjygYwo8Gq3P\u0026limit=5","prev":"/api/v1/sites/testsite/pages/basic_pages?__nonce=CVvuPUtTqo8pMqQ1ffIGPA\u0026__token=AHedyRZyfUUbVEY79DfNVxp7Fd3oD3DiZ-Dr4LUqfAM8\u0026limit=5"}'
+    http_version:
+  recorded_at: Tue, 30 Oct 2018 20:31:21 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/paginated_get_page3.yml
+++ b/spec/fixtures/paginated_get_page3.yml
@@ -2,36 +2,38 @@
 http_interactions:
 - request:
     method: get
-    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3&limit%5B%5D=11
+    uri: https://testnation.nationbuilder.com/api/v1/sites/testsite/pages/basic_pages?limit=11
     body:
       encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.7.0.1, ruby 2.1.6 (2015-04-13))
+      - HTTPClient/1.0 (2.7.0.1, ruby 2.5.1 (2018-03-29))
       Accept:
       - application/json
       Date:
-      - Wed, 23 Nov 2016 19:17:09 GMT
+      - Tue, 30 Oct 2018 20:31:20 GMT
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer 03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
   response:
     status:
       code: 200
       message: OK
     headers:
-      Server:
-      - Apache/2.4.7 (Ubuntu)
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"d54fc875e173fde01924a654d3170d42-gzip"
+      - W/"f0c238b14c726803333f30faa1c36eb1-gzip"
       Nation-Ratelimit-Limit:
       - '999999'
       Nation-Ratelimit-Remaining:
       - '999999'
       Nation-Ratelimit-Reset:
-      - '1479945600'
+      - '1540944000'
+      Server:
+      - Apache/2.4.7 (Ubuntu)
       Status:
       - 200 OK
       Vary:
@@ -39,7 +41,9 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
-      - SAMEORIGIN
+      - ALLOWALL
+      X-Middleware-Start:
+      - t=1540931480515057
       X-Powered-By:
       - Phusion Passenger Enterprise 5.0.28
       X-Pulse-Approved:
@@ -49,39 +53,39 @@ http_interactions:
       X-Ratelimit-Limit:
       - 10s
       X-Ratelimit-Remaining:
-      - '98'
+      - '99'
       X-Ratelimit-Reset:
-      - '1479928639'
+      - '1540931490'
       X-Request-Id:
-      - cda7fcad-9a45-4fb4-ac1b-b95ff95419a5
+      - 0c5333c7-7383-4216-9f7a-e9263a8e6f96
       X-Runtime:
-      - '0.068206'
-      X-Xss-Protection:
-      - 1; mode=block
+      - '0.094467'
+      X-Served-By:
+      - api11
       Content-Length:
       - '1158'
       Expires:
-      - Wed, 23 Nov 2016 19:17:09 GMT
+      - Tue, 30 Oct 2018 20:31:20 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
       Date:
-      - Wed, 23 Nov 2016 19:17:09 GMT
+      - Tue, 30 Oct 2018 20:31:20 GMT
       Connection:
       - keep-alive
-      Set-Cookie:
-      - _cookies_enabled=1479928629; path=/
+      Use-Proxy:
+      - 'True'
     body:
       encoding: UTF-8
-      string: '{"results":[{"slug":"basic_1","path":"/basic_1","status":"unlisted","site_slug":"organizeralexandreschmitt","name":"Basic
-        1","headline":"Basic 1","title":"Basic 1 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":99,"content":null},{"slug":"about","path":"/","status":"published","site_slug":"organizeralexandreschmitt","name":"About","headline":"About
+      string: '{"results":[{"slug":"basic_1","path":"/basic_1","status":"unlisted","site_slug":"testsite","name":"Basic
+        1","headline":"Basic 1","title":"Basic 1 - Test site","excerpt":null,"author_id":1,"published_at":null,"external_id":null,"tags":[],"id":99,"content":null},{"slug":"about","path":"/","status":"published","site_slug":"testsite","name":"About","headline":"About
         your nation","title":"About - Test site","excerpt":"","author_id":1,"published_at":"2013-07-08T18:07:00Z","external_id":null,"tags":[],"id":98,"content":"\u003cp\u003eThis
         is where you tell everyone about your nation. Explain who you are and what
         you would like people to do. \u003c/p\u003e\r\n\u003cp\u003e \u003c/p\u003e\r\n\u003cp\u003e\u003cstrong\u003eTo
         change this content, click \"Edit this page\" in the Supporter Nav on the
         right,\u003cbr\u003eor from your Control Panel navigate to Websites \u0026gt;
-        [about] \u0026gt; Content.\u003c/strong\u003e\u003c/p\u003e"}],"next":null,"prev":"/api/v1/sites/organizeralexandreschmitt/pages/basic_pages?__nonce=Wm_pYQzOnIFKyM2TN1e2bw\u0026__token=AJ376yMPDjR_cerB0Cn9KDbA63_-o4A6j3CvvQDJKM1u\u0026limit=11"}'
-    http_version: 
-  recorded_at: Wed, 23 Nov 2016 19:17:09 GMT
+        [about] \u0026gt; Content.\u003c/strong\u003e\u003c/p\u003e"}],"next":null,"prev":"/api/v1/sites/testsite/pages/basic_pages?__nonce=3FjC9RMiBJ1JLokUYO_nMA\u0026__token=AMkccEmidlam_gzpi8opc2vIIpfOPX5oChdaSJcBFnE0\u0026limit=11"}'
+    http_version:
+  recorded_at: Tue, 30 Oct 2018 20:31:20 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/parametered_get.yml
+++ b/spec/fixtures/parametered_get.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/people/search?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3&custom_values%5Bgraduation_year%5D=2008&first_name=Alex&limit=2
+    uri: https://testnation.nationbuilder.com/api/v1/people/search?custom_values%5Bgraduation_year%5D=2008&first_name=Alex&limit=2
     body:
       encoding: UTF-8
       string: ''
@@ -12,9 +12,11 @@ http_interactions:
       Accept:
       - application/json
       Date:
-      - Mon, 29 Oct 2018 20:20:03 GMT
+      - Tue, 30 Oct 2018 20:20:37 GMT
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer 03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
   response:
     status:
       code: 200
@@ -23,13 +25,13 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"22dbb824b3d20ee8ecc94045fc22785f-gzip"
+      - W/"3481f6fe1b20ecf9888593cf0e1ec0b6-gzip"
       Nation-Ratelimit-Limit:
       - '999999'
       Nation-Ratelimit-Remaining:
       - '999999'
       Nation-Ratelimit-Reset:
-      - '1540857600'
+      - '1540944000'
       Server:
       - Apache/2.4.7 (Ubuntu)
       Status:
@@ -41,7 +43,7 @@ http_interactions:
       X-Frame-Options:
       - ALLOWALL
       X-Middleware-Start:
-      - t=1540844404429755
+      - t=1540930838114489
       X-Powered-By:
       - Phusion Passenger Enterprise 5.0.28
       X-Pulse-Approved:
@@ -53,30 +55,30 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '99'
       X-Ratelimit-Reset:
-      - '1540844414'
+      - '1540930848'
       X-Request-Id:
-      - 510effc7-749c-43e5-ab66-713f36aa8e1e
+      - '078e950f-e13c-435e-8c70-250e95ac6efe'
       X-Runtime:
-      - '0.132674'
+      - '0.126909'
       X-Served-By:
-      - api11
+      - api10
       Content-Length:
       - '2785'
       Expires:
-      - Mon, 29 Oct 2018 20:20:04 GMT
+      - Tue, 30 Oct 2018 20:20:38 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
       Date:
-      - Mon, 29 Oct 2018 20:20:04 GMT
+      - Tue, 30 Oct 2018 20:20:38 GMT
       Connection:
       - keep-alive
       Use-Proxy:
       - 'True'
     body:
       encoding: UTF-8
-      string: '{"results":[{"birthdate":null,"city_district":null,"civicrm_id":null,"county_district":null,"county_file_id":null,"created_at":"2018-10-29T19:09:52Z","datatrust_id":null,"do_not_call":false,"do_not_contact":false,"dw_id":null,"email":"alexdoe@exampleschool.edu","email_opt_in":true,"employer":"","external_id":null,"federal_district":null,"fire_district":null,"first_name":"Alex","has_facebook":false,"id":352989,"is_twitter_follower":false,"is_volunteer":false,"judicial_district":null,"labour_region":null,"last_name":"Doe","linkedin_id":null,"mobile":"","mobile_opt_in":true,"middle_name":"","nbec_guid":null,"ngp_id":null,"note":"","occupation":"","party":"","pf_strat_id":null,"phone":"","precinct_id":null,"primary_address":null,"profile_image_url_ssl":"https://d3n8a8pro7vhmx.cloudfront.net/assets/notifier/profile-avatar.png","recruiter_id":null,"rnc_id":null,"rnc_regid":null,"salesforce_id":null,"school_district":null,"school_sub_district":null,"sex":"","signup_type":0,"state_file_id":null,"state_lower_district":null,"state_upper_district":null,"support_level":null,"supranational_district":null,"tags":[],"twitter_id":null,"twitter_name":null,"updated_at":"2018-10-29T19:10:05Z","van_id":null,"village_district":null,"ward":null,"work_phone_number":"","graduation_year":2008.0},{"birthdate":null,"city_district":null,"civicrm_id":null,"county_district":null,"county_file_id":null,"created_at":"2018-05-31T00:07:29Z","datatrust_id":null,"do_not_call":false,"do_not_contact":false,"dw_id":null,"email":"alex@exampleschool.edu","email_opt_in":true,"employer":"","external_id":null,"federal_district":null,"fire_district":null,"first_name":"Alex","has_facebook":false,"id":352955,"is_twitter_follower":false,"is_volunteer":false,"judicial_district":null,"labour_region":null,"last_name":"Smith","linkedin_id":null,"mobile":"","mobile_opt_in":true,"middle_name":"","nbec_guid":null,"ngp_id":null,"note":null,"occupation":"","party":"","pf_strat_id":null,"phone":"","precinct_id":null,"primary_address":null,"profile_image_url_ssl":"https://d3n8a8pro7vhmx.cloudfront.net/assets/notifier/profile-avatar.png","recruiter_id":null,"rnc_id":null,"rnc_regid":null,"salesforce_id":null,"school_district":null,"school_sub_district":null,"sex":"","signup_type":0,"state_file_id":null,"state_lower_district":null,"state_upper_district":null,"support_level":null,"supranational_district":null,"tags":[],"twitter_id":null,"twitter_name":null,"updated_at":"2018-10-29T19:09:34Z","van_id":null,"village_district":null,"ward":null,"work_phone_number":"","graduation_year":2008.0}],"next":"/api/v1/people/search?__nonce=Z95uFNEYek3JMk7aZWYL3A\u0026__token=AFwi3WBpELaAwUEjhPFiVsRvUjLoIfXrD-3u5Iu2sJah\u0026custom_values%5Bgraduation_year%5D=2008\u0026first_name=Alex\u0026limit=2","prev":null}'
-    http_version:
-  recorded_at: Mon, 29 Oct 2018 20:20:04 GMT
+      string: '{"results":[{"birthdate":null,"city_district":null,"civicrm_id":null,"county_district":null,"county_file_id":null,"created_at":"2018-10-29T19:09:52Z","datatrust_id":null,"do_not_call":false,"do_not_contact":false,"dw_id":null,"email":"alexdoe@exampleschool.edu","email_opt_in":true,"employer":"","external_id":null,"federal_district":null,"fire_district":null,"first_name":"Alex","has_facebook":false,"id":352989,"is_twitter_follower":false,"is_volunteer":false,"judicial_district":null,"labour_region":null,"last_name":"Doe","linkedin_id":null,"mobile":"","mobile_opt_in":true,"middle_name":"","nbec_guid":null,"ngp_id":null,"note":"","occupation":"","party":"","pf_strat_id":null,"phone":"","precinct_id":null,"primary_address":null,"profile_image_url_ssl":"https://d3n8a8pro7vhmx.cloudfront.net/assets/notifier/profile-avatar.png","recruiter_id":null,"rnc_id":null,"rnc_regid":null,"salesforce_id":null,"school_district":null,"school_sub_district":null,"sex":"","signup_type":0,"state_file_id":null,"state_lower_district":null,"state_upper_district":null,"support_level":null,"supranational_district":null,"tags":[],"twitter_id":null,"twitter_name":null,"updated_at":"2018-10-29T19:10:05Z","van_id":null,"village_district":null,"ward":null,"work_phone_number":"","graduation_year":2008.0},{"birthdate":null,"city_district":null,"civicrm_id":null,"county_district":null,"county_file_id":null,"created_at":"2018-05-31T00:07:29Z","datatrust_id":null,"do_not_call":false,"do_not_contact":false,"dw_id":null,"email":"alex@exampleschool.edu","email_opt_in":true,"employer":"","external_id":null,"federal_district":null,"fire_district":null,"first_name":"Alex","has_facebook":false,"id":352955,"is_twitter_follower":false,"is_volunteer":false,"judicial_district":null,"labour_region":null,"last_name":"Smith","linkedin_id":null,"mobile":"","mobile_opt_in":true,"middle_name":"","nbec_guid":null,"ngp_id":null,"note":null,"occupation":"","party":"","pf_strat_id":null,"phone":"","precinct_id":null,"primary_address":null,"profile_image_url_ssl":"https://d3n8a8pro7vhmx.cloudfront.net/assets/notifier/profile-avatar.png","recruiter_id":null,"rnc_id":null,"rnc_regid":null,"salesforce_id":null,"school_district":null,"school_sub_district":null,"sex":"","signup_type":0,"state_file_id":null,"state_lower_district":null,"state_upper_district":null,"support_level":null,"supranational_district":null,"tags":[],"twitter_id":null,"twitter_name":null,"updated_at":"2018-10-29T19:09:34Z","van_id":null,"village_district":null,"ward":null,"work_phone_number":"","graduation_year":2008.0}],"next":"/api/v1/people/search?__nonce=cmDsSJ54eXx2snX-qOjspw\u0026__token=AEQi82Ef8T3_0Xks78eam-vC-YYtqVmOZai4CHntX0hH\u0026custom_values%5Bgraduation_year%5D=2008\u0026first_name=Alex\u0026limit=2","prev":null}'
+    http_version: 
+  recorded_at: Tue, 30 Oct 2018 20:20:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/parametered_post.yml
+++ b/spec/fixtures/parametered_post.yml
@@ -2,42 +2,46 @@
 http_interactions:
 - request:
     method: post
-    uri: https://organizeralexandreschmitt.nationbuilder.com/api/v1/people?access_token=03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
+    uri: https://testnation.nationbuilder.com/api/v1/people
     body:
       encoding: UTF-8
-      string: '{"person":{"email":"bob@example.com","last_name":"Smith","first_name":"Bob"},"access_token":"03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3"}'
+      string: '{"person":{"email":"bob@example.com","last_name":"Smith","first_name":"Bob"}}'
     headers:
       User-Agent:
-      - HTTPClient/1.0 (2.7.0.1, ruby 2.1.6 (2015-04-13))
+      - HTTPClient/1.0 (2.7.0.1, ruby 2.5.1 (2018-03-29))
       Accept:
       - application/json
       Date:
-      - Wed, 23 Nov 2016 19:16:54 GMT
+      - Tue, 30 Oct 2018 20:24:01 GMT
       Content-Type:
       - application/json
+      Authorization:
+      - Bearer 03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3
   response:
     status:
       code: 201
       message: Created
     headers:
-      Server:
-      - Apache/2.4.7 (Ubuntu)
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"b6d45f34158428614bbb946bfc528007"
+      - W/"3b355ff221654ef5686b1b9a5242d03b"
       Nation-Ratelimit-Limit:
       - '999999'
       Nation-Ratelimit-Remaining:
       - '999999'
       Nation-Ratelimit-Reset:
-      - '1479945600'
+      - '1540944000'
+      Server:
+      - Apache/2.4.7 (Ubuntu)
       Status:
       - 201 Created
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
-      - SAMEORIGIN
+      - ALLOWALL
+      X-Middleware-Start:
+      - t=1540931041929836
       X-Powered-By:
       - Phusion Passenger Enterprise 5.0.28
       X-Pulse-Approved:
@@ -47,33 +51,33 @@ http_interactions:
       X-Ratelimit-Limit:
       - 10s
       X-Ratelimit-Remaining:
-      - '97'
+      - '99'
       X-Ratelimit-Reset:
-      - '1479928618'
+      - '1540931051'
       X-Request-Id:
-      - c86e279e-27c3-4271-8f3a-9a6873e44c4f
+      - 4f07a8e2-bc5f-4bc5-8adc-369d194d188c
       X-Runtime:
-      - '0.632973'
-      X-Xss-Protection:
-      - 1; mode=block
+      - '0.266915'
+      X-Served-By:
+      - api13
       Content-Length:
-      - '5448'
+      - '5073'
       Expires:
-      - Wed, 23 Nov 2016 19:16:55 GMT
+      - Tue, 30 Oct 2018 20:24:02 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
       Date:
-      - Wed, 23 Nov 2016 19:16:55 GMT
+      - Tue, 30 Oct 2018 20:24:02 GMT
       Connection:
       - keep-alive
-      Set-Cookie:
-      - _cookies_enabled=1479928615; path=/
+      Use-Proxy:
+      - 'True'
     body:
       encoding: UTF-8
-      string: '{"person":{"birthdate":null,"city_district":null,"civicrm_id":null,"county_district":null,"county_file_id":null,"created_at":"2016-11-23T19:16:55Z","datatrust_id":null,"do_not_call":false,"do_not_contact":false,"dw_id":null,"email":"bob@example.com","email_opt_in":true,"employer":null,"external_id":null,"federal_district":null,"fire_district":null,"first_name":"Bob","has_facebook":false,"id":278882,"is_twitter_follower":false,"is_volunteer":false,"judicial_district":null,"labour_region":null,"last_name":"Smith","linkedin_id":null,"mobile":null,"mobile_opt_in":true,"nbec_guid":null,"ngp_id":null,"note":null,"occupation":null,"party":null,"pf_strat_id":null,"phone":null,"precinct_id":null,"primary_address":null,"profile_image_url_ssl":"https://d3n8a8pro7vhmx.cloudfront.net/assets/icons/buddy.png","recruiter_id":null,"rnc_id":null,"rnc_regid":null,"salesforce_id":null,"school_district":null,"school_sub_district":null,"sex":null,"signup_type":0,"state_file_id":null,"state_lower_district":null,"state_upper_district":null,"support_level":null,"supranational_district":null,"tags":[],"twitter_id":null,"twitter_name":null,"updated_at":"2016-11-23T19:16:55Z","van_id":null,"village_district":null,"ward":null,"work_phone_number":null,"active_customer_expires_at":null,"active_customer_started_at":null,"author":null,"author_id":null,"auto_import_id":null,"availability":null,"ballots":[],"banned_at":null,"billing_address":null,"bio":null,"call_status_id":null,"call_status_name":null,"capital_amount_in_cents":0,"children_count":0,"church":null,"city_sub_district":null,"closed_invoices_amount_in_cents":null,"closed_invoices_count":null,"contact_status_id":null,"contact_status_name":null,"could_vote_status":false,"demo":null,"donations_amount_in_cents":0,"donations_amount_this_cycle_in_cents":0,"donations_count":0,"donations_count_this_cycle":0,"donations_pledged_amount_in_cents":0,"donations_raised_amount_in_cents":0,"donations_raised_amount_this_cycle_in_cents":0,"donations_raised_count":0,"donations_raised_count_this_cycle":0,"donations_to_raise_amount_in_cents":0,"email1":"bob@example.com","email1_is_bad":false,"email2":null,"email2_is_bad":false,"email3":null,"email3_is_bad":false,"email4":null,"email4_is_bad":false,"emails":[{"email_address":"bob@example.com","email_number":1,"is_bad":false,"is_primary":true}],"ethnicity":null,"facebook_address":null,"facebook_profile_url":null,"facebook_updated_at":null,"facebook_username":null,"fax_number":null,"federal_donotcall":false,"first_donated_at":null,"first_fundraised_at":null,"first_invoice_at":null,"first_prospect_at":null,"first_recruited_at":null,"first_supporter_at":"2016-11-23T19:16:55Z","first_volunteer_at":null,"full_name":"Bob
-        Smith","home_address":null,"import_id":null,"inferred_party":null,"inferred_support_level":null,"invoice_payments_amount_in_cents":0,"invoice_payments_referred_amount_in_cents":0,"invoices_amount_in_cents":null,"invoices_count":null,"is_absentee_voter":null,"is_active_voter":null,"is_deceased":false,"is_donor":false,"is_dropped_from_file":null,"is_early_voter":null,"is_fundraiser":false,"is_ignore_donation_limits":false,"is_leaderboardable":true,"is_mobile_bad":false,"is_permanent_absentee_voter":null,"is_possible_duplicate":false,"is_profile_private":false,"is_profile_searchable":true,"is_prospect":false,"is_supporter":true,"is_survey_question_private":false,"language":null,"last_call_id":null,"last_contacted_at":null,"last_contacted_by":null,"last_donated_at":null,"last_fundraised_at":null,"last_invoice_at":null,"last_rule_violation_at":null,"legal_name":null,"locale":null,"mailing_address":null,"marital_status":null,"media_market_name":null,"meetup_id":null,"meetup_address":null,"membership_expires_at":null,"membership_level_name":null,"membership_started_at":null,"middle_name":null,"mobile_normalized":null,"nbec_precinct_code":null,"nbec_precinct":null,"note_updated_at":null,"outstanding_invoices_amount_in_cents":null,"outstanding_invoices_count":null,"overdue_invoices_count":0,"page_slug":null,"parent":null,"parent_id":null,"party_member":null,"phone_normalized":null,"phone_time":null,"precinct_code":null,"precinct_name":null,"prefix":null,"previous_party":null,"primary_email_id":1,"priority_level":null,"priority_level_changed_at":null,"profile_content":null,"profile_content_html":null,"profile_headline":null,"received_capital_amount_in_cents":0,"recruiter":null,"recruits_count":0,"registered_address":null,"registered_at":null,"religion":null,"rule_violations_count":0,"signup_sources":[],"spent_capital_amount_in_cents":0,"submitted_address":null,"subnations":[],"suffix":null,"support_level_changed_at":null,"support_probability_score":null,"township":null,"turnout_probability_score":null,"twitter_address":null,"twitter_description":null,"twitter_followers_count":null,"twitter_friends_count":null,"twitter_location":null,"twitter_login":null,"twitter_updated_at":null,"twitter_website":null,"unsubscribed_at":null,"user_submitted_address":null,"username":null,"voter_updated_at":null,"warnings_count":0,"website":null,"work_address":null,"bag_preference":null,"do_you_drive_a_fork_lift":null,"have_you_been_involved_in_an_election_campaign_before_":null,"sub_branch":null,"sams_custom_field":null,"mrow":null,"headshot_url":null,"university":null,"membership_number":null,"number":null,"check":null,"industry_name":null,"yes":null,"next_election":null,"filing_window":null},"precinct":null}'
+      string: '{"person":{"birthdate":null,"city_district":null,"civicrm_id":null,"county_district":null,"county_file_id":null,"created_at":"2018-10-30T20:24:02Z","datatrust_id":null,"do_not_call":false,"do_not_contact":false,"dw_id":null,"email":"bob@example.com","email_opt_in":true,"employer":null,"external_id":null,"federal_district":null,"fire_district":null,"first_name":"Bob","has_facebook":false,"id":352990,"is_twitter_follower":false,"is_volunteer":false,"judicial_district":null,"labour_region":null,"last_name":"Smith","linkedin_id":null,"mobile":null,"mobile_opt_in":true,"middle_name":"","nbec_guid":null,"ngp_id":null,"note":null,"occupation":null,"party":null,"pf_strat_id":null,"phone":null,"precinct_id":null,"primary_address":null,"profile_image_url_ssl":"https://d3n8a8pro7vhmx.cloudfront.net/assets/notifier/profile-avatar.png","recruiter_id":null,"rnc_id":null,"rnc_regid":null,"salesforce_id":null,"school_district":null,"school_sub_district":null,"sex":null,"signup_type":0,"state_file_id":null,"state_lower_district":null,"state_upper_district":null,"support_level":null,"supranational_district":null,"tags":[],"twitter_id":null,"twitter_name":null,"updated_at":"2018-10-30T20:24:02Z","van_id":null,"village_district":null,"ward":null,"work_phone_number":null,"active_customer_expires_at":null,"active_customer_started_at":null,"author":null,"author_id":null,"auto_import_id":null,"availability":null,"ballots":[],"banned_at":null,"billing_address":null,"bio":null,"call_status_id":null,"call_status_name":null,"capital_amount_in_cents":0,"children_count":0,"church":null,"city_sub_district":null,"closed_invoices_amount_in_cents":0,"closed_invoices_count":null,"contact_status_id":null,"contact_status_name":null,"could_vote_status":false,"demo":null,"donations_amount_in_cents":0,"donations_amount_this_cycle_in_cents":0,"donations_count":0,"donations_count_this_cycle":0,"donations_pledged_amount_in_cents":0,"donations_raised_amount_in_cents":0,"donations_raised_amount_this_cycle_in_cents":0,"donations_raised_count":0,"donations_raised_count_this_cycle":0,"donations_to_raise_amount_in_cents":0,"email1":"bob@example.com","email1_is_bad":false,"email2":null,"email2_is_bad":false,"email3":null,"email3_is_bad":false,"email4":null,"email4_is_bad":false,"emails":[{"email_address":"bob@example.com","email_number":1,"is_bad":false,"is_primary":true}],"ethnicity":null,"facebook_address":null,"facebook_profile_url":null,"facebook_updated_at":null,"facebook_username":null,"fax_number":null,"federal_donotcall":false,"first_donated_at":null,"first_fundraised_at":null,"first_invoice_at":null,"first_prospect_at":null,"first_recruited_at":null,"first_supporter_at":"2018-10-30T20:24:02Z","first_volunteer_at":null,"full_name":"Bob
+        Smith","home_address":null,"identity_mappings":[],"import_id":null,"inferred_party":null,"inferred_support_level":null,"invoice_payments_amount_in_cents":0,"invoice_payments_referred_amount_in_cents":0,"invoices_amount_in_cents":0,"invoices_count":null,"is_absentee_voter":null,"is_active_voter":null,"is_deceased":false,"is_donor":false,"is_dropped_from_file":null,"is_early_voter":null,"is_fundraiser":false,"is_ignore_donation_limits":false,"is_leaderboardable":true,"is_mobile_bad":false,"is_permanent_absentee_voter":null,"is_possible_duplicate":false,"is_profile_private":false,"is_profile_searchable":true,"is_prospect":false,"is_supporter":true,"is_survey_question_private":false,"language":null,"last_call_id":null,"last_contacted_at":null,"last_contacted_by":null,"last_donated_at":null,"last_fundraised_at":null,"last_invoice_at":null,"last_rule_violation_at":null,"legal_name":null,"locale":null,"mailing_address":null,"marital_status":null,"media_market_name":null,"meetup_id":null,"meetup_address":null,"mobile_normalized":null,"nbec_precinct_code":null,"nbec_precinct":null,"note_updated_at":null,"outstanding_invoices_amount_in_cents":0,"outstanding_invoices_count":null,"overdue_invoices_count":0,"page_slug":null,"parent":null,"parent_id":null,"party_member":null,"phone_normalized":null,"phone_time":null,"precinct_code":null,"precinct_name":null,"prefix":null,"previous_party":null,"primary_email_id":1,"priority_level":null,"priority_level_changed_at":null,"profile_content":null,"profile_content_html":null,"profile_headline":null,"received_capital_amount_in_cents":0,"recruiter":null,"recruits_count":0,"registered_address":null,"registered_at":null,"religion":null,"rule_violations_count":0,"signup_sources":[],"spent_capital_amount_in_cents":0,"submitted_address":null,"subnations":[],"suffix":null,"support_level_changed_at":null,"support_probability_score":null,"township":null,"turnout_probability_score":null,"twitter_address":null,"twitter_description":null,"twitter_followers_count":null,"twitter_friends_count":null,"twitter_location":null,"twitter_login":null,"twitter_updated_at":null,"twitter_website":null,"unsubscribed_at":null,"user_submitted_address":null,"username":null,"voter_updated_at":null,"warnings_count":0,"website":null,"work_address":null,"graduation_year":null},"precinct":null}'
     http_version: 
-  recorded_at: Wed, 23 Nov 2016 19:16:55 GMT
+  recorded_at: Tue, 30 Oct 2018 20:24:02 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lib/nationbuilder/client_spec.rb
+++ b/spec/lib/nationbuilder/client_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe NationBuilder::Client do
 
   let(:client) do
-    NationBuilder::Client.new('organizeralexandreschmitt',
+    NationBuilder::Client.new('testnation',
                               '03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3',
                               retries: 1
                               )
@@ -54,7 +54,7 @@ describe NationBuilder::Client do
   describe '#base_url' do
 
     it 'should contain the nation slug' do
-      expect(client.base_url).to eq('https://organizeralexandreschmitt.nationbuilder.com')
+      expect(client.base_url).to eq('https://testnation.nationbuilder.com')
     end
   end
 

--- a/spec/lib/nationbuilder/paginator_spec.rb
+++ b/spec/lib/nationbuilder/paginator_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe NationBuilder::Paginator do
 
   let(:client) do
-    NationBuilder::Client.new('organizeralexandreschmitt',
+    NationBuilder::Client.new('testnation',
                               '03c22256c06ed11f6bee83673addf26e02a86caa1a5127f4e0815be7223fe4a3')
   end
   let(:response) do
     VCR.use_cassette('paginated_get') do
-      client.call(:basic_pages, :index, site_slug: 'organizeralexandreschmitt', limit: 11)
+      client.call(:basic_pages, :index, site_slug: 'testsite', limit: 11)
     end
   end
 


### PR DESCRIPTION
As a better practice, many reasons behind this are outlined in [this article](https://www.fullcontact.com/blog/never-put-secrets-urls-query-parameters/) by FullContact. 

This also updates all fixtures to be up to date, with some sanitization on the slug / data recorded in them.